### PR TITLE
Added support for both jest and travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
-  - "iojs"
-  - "8.9.4"
+  - "stable"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "iojs"
+  - "8.9.4"

--- a/__tests__/sample-tests.js
+++ b/__tests__/sample-tests.js
@@ -1,3 +1,3 @@
 test('runs a test that should always pass', () => {
-  expect('Will this work?').toBe('Will this work?');
+  expect('Will this work?').toBe('no this will not Will this work?');
 });

--- a/__tests__/sample-tests.js
+++ b/__tests__/sample-tests.js
@@ -1,3 +1,3 @@
 test('runs a test that should always pass', () => {
-  expect('Will this work?').toBe('no this will not Will this work?');
+  expect('Will this work?').toBe('Will this work?');
 });

--- a/__tests__/sample-tests.js
+++ b/__tests__/sample-tests.js
@@ -1,0 +1,3 @@
+test('runs a test that should always pass', () => {
+  expect('Will this work?').toBe('Will this work?');
+});

--- a/package.json
+++ b/package.json
@@ -3,8 +3,11 @@
   "version": "1.0.0",
   "description": "Find picture worthy locations around you",
   "main": "index.js",
+  "jest": {
+    "verbose": true
+  },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "start": "node server/index.js",
     "server-dev": "nodemon server/index.js",
     "react-dev": "webpack -d --watch"
@@ -34,6 +37,7 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.23.0",
     "dotenv": "^5.0.1",
+    "jest": "^22.4.3",
     "webpack": "^3.11.0"
   }
 }

--- a/testing.README.txt
+++ b/testing.README.txt
@@ -1,6 +1,7 @@
 
 ***TRAVIS CI NOTES***
 
+https://www.youtube.com/watch?v=ymPOI4gWQFY
 https://www.youtube.com/watch?v=Uft5KBimzyk
 https://www.youtube.com/watch?v=yoS9fEzkzYA
 

--- a/testing.README.txt
+++ b/testing.README.txt
@@ -1,3 +1,6 @@
+JEST
+  see __tests__/sample-tests.js to see how to write a test.  Any tests in any file in that folder will automatically be ran after running npm test in terminal or with travis ci after pushing to github.
+
 main link for travis CI for node: https://docs.travis-ci.com/user/languages/javascript-with-nodejs/
 ***TRAVIS CI NOTES***
 

--- a/testing.README.txt
+++ b/testing.README.txt
@@ -1,4 +1,4 @@
-
+main link for travis CI for node: https://docs.travis-ci.com/user/languages/javascript-with-nodejs/
 ***TRAVIS CI NOTES***
 
 https://www.youtube.com/watch?v=ymPOI4gWQFY

--- a/testing.README.txt
+++ b/testing.README.txt
@@ -1,0 +1,26 @@
+
+***TRAVIS CI NOTES***
+
+https://www.youtube.com/watch?v=Uft5KBimzyk
+https://www.youtube.com/watch?v=yoS9fEzkzYA
+
+CONTINUOUS INTEGRATION
+  Continuous Integration is the practice of merging small code changes frequently.
+
+CI 
+  When we runa build, Travis CI clnes our Github REpository into a virtual environment and carries out a series of tasks to build and test our code.  If we pass all the tests Travis CI can deploy our code to heroku.
+
+  there is a TravisCI .org for public repositories (free).  The .com is not free.
+
+COMMON WORDS FOR TRAVIS CI IN DOCS
+  JOB - an automated process that clones our repository and compiles code and runs tests  if it returns a 0 we pass if it returns anything but a 0 we failed.
+
+  PHASE -- the steps of a job.  For example sinstall and script and then optional deploy
+
+  BUILD- a group of jobs
+
+  STAGE -- a group of jobs that run in parallel (Not important?)
+
+COMMON BUILD PROBLEMS:
+  The following page is for troubleshooting common issues with the build: https://docs.travis-ci.com/user/common-build-problems/
+


### PR DESCRIPTION
Check out testing.README.txt for more info on travis ci
Check out __tests__/sample-tests.js for an example of how to do a test for jest.
To run tests run npm test in command line
Travis ci will automatically run tests when pushing to github.